### PR TITLE
Chore: Drupal core compatibility

### DIFF
--- a/localgov_design_system.info.yml
+++ b/localgov_design_system.info.yml
@@ -1,7 +1,7 @@
 name: "LocalGov Design System"
 description: "Your sub-theme, which uses localgov_base as its base theme."
 type: theme
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ">=9"
 base theme: "localgov_base"
 
 libraries-extend:


### PR DESCRIPTION
Rather than restricting this theme to Drupal 8 and 9, choosing a looser version requirement specifying anything above Drupal 9.